### PR TITLE
docs: improve OpenStack example

### DIFF
--- a/examples/openstack/control-plane.tf
+++ b/examples/openstack/control-plane.tf
@@ -6,7 +6,7 @@ resource "openstack_compute_instance_v2" "talos_control_plane" {
   image_id    = openstack_images_image_v2.talos.id
 
   network {
-    name = var.network_name
+    port = openstack_networking_port_v2.talos_control_plane[count.index].id
   }
 
   user_data = yamlencode(merge(
@@ -18,6 +18,14 @@ resource "openstack_compute_instance_v2" "talos_control_plane" {
           controlPlane = {
             endpoint = "https://${openstack_lb_loadbalancer_v2.talos_control_plane.vip_address}"
           }
+        }
+      )
+      machine = merge(
+        local.control_plane_config.machine,
+        {
+          certSANs = [
+            openstack_networking_floatingip_v2.talos_control_plane[count.index].address,
+          ]
         }
       )
     }

--- a/examples/openstack/floating_ips.tf
+++ b/examples/openstack/floating_ips.tf
@@ -1,0 +1,15 @@
+resource "openstack_networking_floatingip_v2" "talos_control_plane" {
+  count      = var.control_plane_number
+  depends_on = [openstack_networking_router_interface_v2.talos]
+
+  pool    = var.floating_ip_network_name
+  port_id = openstack_networking_port_v2.talos_control_plane[count.index].id
+}
+
+resource "openstack_networking_floatingip_v2" "talos_worker" {
+  count      = var.worker_number
+  depends_on = [openstack_networking_router_interface_v2.talos]
+
+  pool    = var.floating_ip_network_name
+  port_id = openstack_networking_port_v2.talos_worker[count.index].id
+}

--- a/examples/openstack/kubernetes.tf
+++ b/examples/openstack/kubernetes.tf
@@ -1,5 +1,9 @@
 resource "talos_bootstrap" "openstack" {
-  endpoint    = openstack_compute_instance_v2.talos_control_plane[0].access_ip_v4
+  depends_on = [
+    openstack_compute_instance_v2.talos_control_plane[0],
+  ]
+
+  endpoint    = openstack_networking_floatingip_v2.talos_control_plane[0].address
   machine_ca  = base64decode(local.talos_config.contexts.openstack.ca)
   machine_crt = base64decode(local.talos_config.contexts.openstack.crt)
   machine_key = base64decode(local.talos_config.contexts.openstack.key)
@@ -10,7 +14,7 @@ output "kubeconfig" {
 }
 
 provider "kubernetes" {
-  host                   = openstack_lb_loadbalancer_v2.talos_control_plane.vip_address
+  host                   = "https://${openstack_lb_loadbalancer_v2.talos_control_plane.vip_address}"
   client_certificate     = talos_bootstrap.openstack.client_certificate
   client_key             = talos_bootstrap.openstack.client_key
   cluster_ca_certificate = talos_bootstrap.openstack.cluster_ca_certificate

--- a/examples/openstack/load-balancer.tf
+++ b/examples/openstack/load-balancer.tf
@@ -1,10 +1,6 @@
-data "openstack_networking_network_v2" "talos_network" {
-  name = var.network_name
-}
-
 resource "openstack_lb_loadbalancer_v2" "talos_control_plane" {
   name           = "talos-control-plane"
-  vip_network_id = data.openstack_networking_network_v2.talos_network.id
+  vip_network_id = var.external_network
 }
 
 resource "openstack_lb_listener_v2" "talos_control_plane" {
@@ -33,7 +29,8 @@ resource "openstack_lb_member_v2" "talos_control_plane" {
   count = var.control_plane_number
 
   name          = "talos-control-plane-${count.index}"
-  address       = openstack_compute_instance_v2.talos_control_plane[count.index].network[0].fixed_ip_v4
+  address       = openstack_networking_port_v2.talos_control_plane[count.index].all_fixed_ips[0]
   pool_id       = openstack_lb_pool_v2.talos_control_plane.id
   protocol_port = 6443
+  subnet_id     = openstack_networking_subnet_v2.talos_internal_ipv4.id
 }

--- a/examples/openstack/local-values.tf
+++ b/examples/openstack/local-values.tf
@@ -2,4 +2,8 @@ locals {
   control_plane_config = yamldecode(file("${path.module}/controlplane.yaml"))
   talos_config         = yamldecode(file("${path.module}/talosconfig"))
   worker_config        = yamldecode(file("${path.module}/worker.yaml"))
+  node_types = {
+    control_plane = "control-plane"
+    worker        = "worker"
+  }
 }

--- a/examples/openstack/network.tf
+++ b/examples/openstack/network.tf
@@ -1,0 +1,23 @@
+resource "openstack_networking_network_v2" "talos_internal" {
+  name = "talos-internal"
+}
+
+resource "openstack_networking_subnet_v2" "talos_internal_ipv4" {
+  name       = "talos-internal-ipv4"
+  cidr       = "192.168.1.0/24"
+  ip_version = 4
+  network_id = openstack_networking_network_v2.talos_internal.id
+  dns_nameservers = [
+    "1.1.1.1",
+    "1.0.0.1",
+  ]
+}
+
+resource "openstack_networking_router_v2" "talos" {
+  external_network_id = var.floating_ip_network_id
+}
+
+resource "openstack_networking_router_interface_v2" "talos" {
+  router_id = openstack_networking_router_v2.talos.id
+  subnet_id = openstack_networking_subnet_v2.talos_internal_ipv4.id
+}

--- a/examples/openstack/ports.tf
+++ b/examples/openstack/ports.tf
@@ -1,0 +1,29 @@
+resource "openstack_networking_port_v2" "talos_control_plane" {
+  count = var.control_plane_number
+
+  name       = "talos-control-plane-${count.index}"
+  network_id = openstack_networking_network_v2.talos_internal.id
+  security_group_ids = [
+    openstack_networking_secgroup_v2.talos_external["control_plane"].id,
+    openstack_networking_secgroup_v2.talos_allow_internal.id,
+  ]
+
+  fixed_ip {
+    subnet_id = openstack_networking_subnet_v2.talos_internal_ipv4.id
+  }
+}
+
+resource "openstack_networking_port_v2" "talos_worker" {
+  count = var.worker_number
+
+  name       = "talos-worker-${count.index}"
+  network_id = openstack_networking_network_v2.talos_internal.id
+  security_group_ids = [
+    openstack_networking_secgroup_v2.talos_external["worker"].id,
+    openstack_networking_secgroup_v2.talos_allow_internal.id,
+  ]
+
+  fixed_ip {
+    subnet_id = openstack_networking_subnet_v2.talos_internal_ipv4.id
+  }
+}

--- a/examples/openstack/security-groups.tf
+++ b/examples/openstack/security-groups.tf
@@ -1,0 +1,63 @@
+resource "openstack_networking_secgroup_v2" "talos_allow_internal" {
+  name = "talos-allow-internal"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "talos_allow_internal_ipv4" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_group_id   = openstack_networking_secgroup_v2.talos_allow_internal.id
+  security_group_id = openstack_networking_secgroup_v2.talos_allow_internal.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "talos_allow_internal_ipv6" {
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  remote_group_id   = openstack_networking_secgroup_v2.talos_allow_internal.id
+  security_group_id = openstack_networking_secgroup_v2.talos_allow_internal.id
+}
+
+resource "openstack_networking_secgroup_v2" "talos_external" {
+  for_each = local.node_types
+
+  name = "talos-external-${each.value}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "kubernetes_api_ipv4" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  security_group_id = openstack_networking_secgroup_v2.talos_external["control_plane"].id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "kubernetes_api_ipv6" {
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  security_group_id = openstack_networking_secgroup_v2.talos_external["control_plane"].id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "talos_api_ipv4" {
+  for_each = local.node_types
+
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 50000
+  port_range_max    = 50000
+  security_group_id = openstack_networking_secgroup_v2.talos_external[each.key].id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "talos_api_ipv6" {
+  for_each = local.node_types
+
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 50000
+  port_range_max    = 50000
+  security_group_id = openstack_networking_secgroup_v2.talos_external[each.key].id
+}

--- a/examples/openstack/variables.tf
+++ b/examples/openstack/variables.tf
@@ -18,6 +18,21 @@ variable "worker_flavor" {
   type        = string
 }
 
+variable "external_network" {
+  description = "ID of external network (for loadbalancer)"
+  type        = string
+}
+
+variable "floating_ip_network_id" {
+  description = "ID of network to allocate floating IP from"
+  type        = string
+}
+
+variable "floating_ip_network_name" {
+  description = "Name of network to allocate floating IP from"
+  type        = string
+}
+
 variable "auth_url" {
   description = "OpenStack authentication URL"
   type        = string
@@ -30,11 +45,6 @@ variable "application_credential_id" {
 variable "application_credential_secret" {
   sensitive = true
   type      = string
-}
-
-variable "network_name" {
-  description = "Network name"
-  default     = "public"
 }
 
 variable "region" {

--- a/examples/openstack/worker.tf
+++ b/examples/openstack/worker.tf
@@ -6,7 +6,7 @@ resource "openstack_compute_instance_v2" "talos_worker" {
   image_id    = openstack_images_image_v2.talos.id
 
   network {
-    name = var.network_name
+    port = openstack_networking_port_v2.talos_worker[count.index].id
   }
 
   user_data = yamlencode(merge(
@@ -18,6 +18,14 @@ resource "openstack_compute_instance_v2" "talos_worker" {
           controlPlane = {
             endpoint = "https://${openstack_lb_loadbalancer_v2.talos_control_plane.vip_address}"
           }
+        }
+      )
+      machine = merge(
+        local.worker_config.machine,
+        {
+          certSANs = [
+            openstack_networking_floatingip_v2.talos_worker[count.index].address,
+          ]
         }
       )
     }


### PR DESCRIPTION
- Private subnet and floating IPs for Talos nodes.
- Use security groups to restrict ingress traffic.