### PR TITLE
chore: allow “deps” Conventional Commits scope

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -24,4 +24,6 @@ policies:
           - revert
           - style
           - test
+        scopes:
+          - deps
         descriptionLength: 72


### PR DESCRIPTION
This allows dependabot’s commit messages that begin with “build(deps):”.