### PR TITLE
ci: allow manually triggering Dependabot PR merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,7 +2,8 @@ name: Dependabot auto-merge
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "34 12 * * *"
+  workflow_dispatch:
 
 jobs:
   auto_merge_dependabot_pr:


### PR DESCRIPTION
Allow manually triggering the “Dependabot auto-merge” workflow, and only
schedule it once a day.