### PR TITLE
ci: don’t hard code GPG key fingerprint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-          fingerprint: E8B4745B17CA1DDCCEB0DD0C095F3E2665AB7BAD
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          fingerprint: ${{ secrets.GPG_FINGERPRINT }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0
         with:


### PR DESCRIPTION
Also prefix all GPG related secrets with `GPG_`.